### PR TITLE
feat: add i18n options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@robertlinde/react-tour-kit",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@robertlinde/react-tour-kit",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robertlinde/react-tour-kit",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Cross-platform guided tour library for React and React Native. Build interactive onboarding experiences with customizable tooltips, smart positioning, cross-page navigation, and async step actions. Fully themeable with TypeScript support.",
   "author": "Robert Linde",
   "license": "MIT",

--- a/src/react-native-platform/components/tour-tooltip.tsx
+++ b/src/react-native-platform/components/tour-tooltip.tsx
@@ -4,15 +4,36 @@ import {type TourTooltipProps} from '../../shared';
 
 const {View, Text, TouchableOpacity, StyleSheet} = require('react-native') as typeof import('react-native');
 
+const defaultI18n = {
+  nextLabel: 'Next',
+  prevLabel: 'Back',
+  finishLabel: 'Done',
+  stepCounterTemplate: 'Step {current} of {total}',
+};
+
 /**
  * Default tooltip component for React Native.
  * Displays tour step content with navigation controls.
  */
 // eslint-disable-next-line func-names -- forwardRef requires named function for display name
 export const TourTooltip = forwardRef(function TourTooltip(
-  {title, content, currentStep, totalSteps, position, isPositioned, onClose, onNext, onPrev, theme}: TourTooltipProps,
+  {
+    title,
+    content,
+    currentStep,
+    totalSteps,
+    position,
+    isPositioned,
+    onClose,
+    onNext,
+    onPrev,
+    theme,
+    i18n,
+  }: TourTooltipProps,
   ref: ForwardedRef<ViewType>,
 ): ReactNode {
+  const {nextLabel, prevLabel, finishLabel, stepCounterTemplate} = {...defaultI18n, ...i18n};
+
   const isFirstStep = currentStep === 0;
   const isLastStep = currentStep === totalSteps - 1;
 
@@ -68,7 +89,7 @@ export const TourTooltip = forwardRef(function TourTooltip(
       <View style={styles.header}>
         <View style={[styles.stepBadge, themedStyles.stepBadge]}>
           <Text style={styles.stepBadgeText}>
-            Step {currentStep + 1} of {totalSteps}
+            {stepCounterTemplate.replace('{current}', String(currentStep + 1)).replace('{total}', String(totalSteps))}
           </Text>
         </View>
         <TouchableOpacity style={styles.closeButton} onPress={onClose}>
@@ -89,7 +110,7 @@ export const TourTooltip = forwardRef(function TourTooltip(
           style={[styles.navButton, styles.prevButton, isFirstStep && styles.buttonDisabled]}
           onPress={onPrev}
         >
-          <Text style={[styles.prevButtonText, isFirstStep && styles.buttonTextDisabled]}>Back</Text>
+          <Text style={[styles.prevButtonText, isFirstStep && styles.buttonTextDisabled]}>{prevLabel}</Text>
         </TouchableOpacity>
 
         {/* Step dots */}
@@ -100,7 +121,7 @@ export const TourTooltip = forwardRef(function TourTooltip(
         </View>
 
         <TouchableOpacity style={[styles.navButton, themedStyles.nextButton]} onPress={onNext}>
-          <Text style={styles.nextButtonText}>{isLastStep ? 'Done' : 'Next'}</Text>
+          <Text style={styles.nextButtonText}>{isLastStep ? finishLabel : nextLabel}</Text>
         </TouchableOpacity>
       </View>
     </View>

--- a/src/react-native-platform/tour-provider.tsx
+++ b/src/react-native-platform/tour-provider.tsx
@@ -28,6 +28,7 @@ export function TourProvider({
   onTourEnd,
   theme,
   platform = nativePlatformAdapter,
+  i18n,
 }: TourProviderProps): JSX.Element {
   const resolvedTheme = useMemo(() => resolveTheme(theme), [theme]);
   const [isActive, setIsActive] = useState(false);
@@ -273,6 +274,7 @@ export function TourProvider({
                 ref={tooltipRef}
                 content={currentTourStep.content}
                 currentStep={currentStep}
+                i18n={i18n}
                 isPositioned={isPositioned}
                 position={tooltipPosition}
                 theme={resolvedTheme}

--- a/src/react-native-platform/types/tour-provider.props.type.ts
+++ b/src/react-native-platform/types/tour-provider.props.type.ts
@@ -1,5 +1,11 @@
 import {type ComponentType, type ReactNode} from 'react';
-import {type PlatformAdapter, type TourOverlayProps, type TourTheme, type TourTooltipProps} from 'src/shared';
+import {
+  type PlatformAdapter,
+  type TourI18n,
+  type TourOverlayProps,
+  type TourTheme,
+  type TourTooltipProps,
+} from 'src/shared';
 
 export type TourProviderProps = {
   readonly children: ReactNode;
@@ -24,4 +30,8 @@ export type TourProviderProps = {
    * Defaults to the native platform adapter.
    */
   readonly platform?: PlatformAdapter;
+  /**
+   * Internationalization options for customizing text strings.
+   */
+  readonly i18n?: TourI18n;
 };

--- a/src/react-platform/components/tour-tooltip.tsx
+++ b/src/react-platform/components/tour-tooltip.tsx
@@ -3,6 +3,15 @@
 import {type JSX, type ForwardedRef, forwardRef} from 'react';
 import {type TourTooltipProps} from '../../shared';
 
+const defaultI18n = {
+  nextLabel: 'Next',
+  prevLabel: 'Back',
+  finishLabel: 'Finish',
+  stepCounterTemplate: '{current} / {total}',
+  closeAriaLabel: 'Close tour',
+  dotAriaLabelTemplate: 'Go to step {step}',
+};
+
 function TourTooltipComponent(
   {
     title,
@@ -16,9 +25,15 @@ function TourTooltipComponent(
     onPrev,
     onGoToStep,
     theme,
+    i18n,
   }: TourTooltipProps,
   ref: ForwardedRef<HTMLDivElement>,
 ): JSX.Element {
+  const {nextLabel, prevLabel, finishLabel, stepCounterTemplate, closeAriaLabel, dotAriaLabelTemplate} = {
+    ...defaultI18n,
+    ...i18n,
+  };
+
   const isLastStep = currentStep === totalSteps - 1;
   const isFirstStep = currentStep === 0;
 
@@ -136,9 +151,9 @@ function TourTooltipComponent(
       <div style={styles.card}>
         <div style={styles.header}>
           <span style={styles.stepTag}>
-            {currentStep + 1} / {totalSteps}
+            {stepCounterTemplate.replace('{current}', String(currentStep + 1)).replace('{total}', String(totalSteps))}
           </span>
-          <button type="button" style={styles.closeButton} aria-label="Close tour" onClick={onClose}>
+          <button type="button" style={styles.closeButton} aria-label={closeAriaLabel} onClick={onClose}>
             ✕
           </button>
         </div>
@@ -158,7 +173,7 @@ function TourTooltipComponent(
             disabled={isFirstStep}
             onClick={onPrev}
           >
-            ← Back
+            {prevLabel}
           </button>
 
           <div style={styles.dotsContainer}>
@@ -170,7 +185,7 @@ function TourTooltipComponent(
                   ...styles.dot,
                   ...(index === currentStep ? styles.dotActive : styles.dotInactive),
                 }}
-                aria-label={`Go to step ${index + 1}`}
+                aria-label={dotAriaLabelTemplate.replace('{step}', String(index + 1))}
                 onClick={() => {
                   onGoToStep(index);
                 }}
@@ -179,7 +194,7 @@ function TourTooltipComponent(
           </div>
 
           <button type="button" style={styles.nextButton} onClick={onNext}>
-            {isLastStep ? 'Finish' : 'Next →'}
+            {isLastStep ? finishLabel : nextLabel}
           </button>
         </div>
       </div>

--- a/src/react-platform/tour-provider.tsx
+++ b/src/react-platform/tour-provider.tsx
@@ -28,6 +28,7 @@ export function TourProvider({
   onTourEnd,
   theme,
   platform = webPlatformAdapter,
+  i18n,
 }: TourProviderProps): JSX.Element {
   const resolvedTheme = useMemo(() => resolveTheme(theme), [theme]);
   const [isActive, setIsActive] = useState(false);
@@ -278,6 +279,7 @@ export function TourProvider({
                   ref={tooltipRef}
                   content={currentTourStep.content}
                   currentStep={currentStep}
+                  i18n={i18n}
                   isPositioned={isPositioned}
                   position={tooltipPosition}
                   theme={resolvedTheme}

--- a/src/react-platform/types/tour-provider.props.type.ts
+++ b/src/react-platform/types/tour-provider.props.type.ts
@@ -1,5 +1,11 @@
 import {type ComponentType, type ForwardRefExoticComponent, type ReactNode, type RefAttributes} from 'react';
-import {type PlatformAdapter, type TourOverlayProps, type TourTheme, type TourTooltipProps} from 'src/shared';
+import {
+  type PlatformAdapter,
+  type TourI18n,
+  type TourOverlayProps,
+  type TourTheme,
+  type TourTooltipProps,
+} from 'src/shared';
 
 export type TourProviderProps = {
   readonly children: ReactNode;
@@ -26,4 +32,8 @@ export type TourProviderProps = {
    * Defaults to the web platform adapter.
    */
   readonly platform?: PlatformAdapter;
+  /**
+   * Internationalization options for customizing text strings.
+   */
+  readonly i18n?: TourI18n;
 };

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -11,6 +11,7 @@ export type {
   TourContextType,
   TourOverlayProps,
   TourTooltipProps,
+  TourI18n,
 } from './types';
 
 export {defaultTheme, resolveTheme} from './types';

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -6,3 +6,4 @@ export type {TourStep} from './tour-step.type';
 export type {TourContextType} from './tour-context.type';
 export type {TourOverlayProps} from './tour-overlay-props.type';
 export type {TourTooltipProps} from './tour-tooltip-props.type';
+export type {TourI18n} from './tour-i18n.type';

--- a/src/shared/types/tour-i18n.type.ts
+++ b/src/shared/types/tour-i18n.type.ts
@@ -1,0 +1,38 @@
+/**
+ * Internationalization options for tour text strings.
+ * All properties are optional and have sensible defaults.
+ */
+export type TourI18n = {
+  /**
+   * Label for the "Next" button.
+   * @default 'Next'
+   */
+  readonly nextLabel?: string;
+  /**
+   * Label for the "Back" button.
+   * @default 'Back'
+   */
+  readonly prevLabel?: string;
+  /**
+   * Label for the "Finish" button (shown on last step).
+   * @default 'Finish' (React) or 'Done' (React Native)
+   */
+  readonly finishLabel?: string;
+  /**
+   * Template string for the step counter. Use `{current}` and `{total}` as placeholders.
+   * @example 'Step {current} of {total}'
+   * @default '{current} / {total}' (React) or 'Step {current} of {total}' (React Native)
+   */
+  readonly stepCounterTemplate?: string;
+  /**
+   * Accessibility label for the close button.
+   * @default 'Close tour'
+   */
+  readonly closeAriaLabel?: string;
+  /**
+   * Template for step dot accessibility labels. Use `{step}` as placeholder.
+   * @example 'Go to step {step}'
+   * @default 'Go to step {step}'
+   */
+  readonly dotAriaLabelTemplate?: string;
+};

--- a/src/shared/types/tour-tooltip-props.type.ts
+++ b/src/shared/types/tour-tooltip-props.type.ts
@@ -1,15 +1,32 @@
+import {type TourI18n} from './tour-i18n.type';
 import {type TourTheme} from './tour-theme.type';
 
+/**
+ * Props for the tooltip component displayed during a tour.
+ */
 export type TourTooltipProps = {
+  /** Title text for the current step. */
   readonly title: string;
+  /** Content/description text for the current step. */
   readonly content: string;
+  /** Zero-based index of the current step. */
   readonly currentStep: number;
+  /** Total number of steps in the tour. */
   readonly totalSteps: number;
+  /** Calculated position for the tooltip. */
   readonly position: {top: number; left: number};
+  /** Whether the tooltip position has been calculated and is ready to display. */
   readonly isPositioned: boolean;
+  /** Callback to close/end the tour. */
   readonly onClose: () => void;
+  /** Callback to advance to the next step. */
   readonly onNext: () => void;
+  /** Callback to go back to the previous step. */
   readonly onPrev: () => void;
+  /** Callback to jump to a specific step by index. */
   readonly onGoToStep: (step: number) => void;
+  /** Theme configuration for styling. */
   readonly theme: Required<TourTheme>;
+  /** Internationalization options for customizing text strings. */
+  readonly i18n?: TourI18n;
 };


### PR DESCRIPTION
This pull request introduces internationalization (i18n) support for the tour tooltip components in both React and React Native platforms, allowing customizable text strings for navigation buttons, step counters, and accessibility labels. The changes add a new `TourI18n` type, update props and usage in tooltip and provider components, and ensure sensible defaults are provided. This makes the library more flexible for localization and accessibility.

### Internationalization support

* Added new `TourI18n` type to define customizable text labels and templates for tooltips, including navigation buttons, step counters, and accessibility labels. (`src/shared/types/tour-i18n.type.ts`, [src/shared/types/tour-i18n.type.tsR1-R38](diffhunk://#diff-0b9b202dc8142eca539792cb382d3b005508418e2e1ac808528b801209bee9fcR1-R38))
* Updated `TourTooltipProps` and `TourProviderProps` to accept an optional `i18n` property for both React and React Native platforms, enabling consumers to override default strings. (`src/shared/types/tour-tooltip-props.type.ts`, [[1]](diffhunk://#diff-eb23931e10142f08a5291ba4a3cdec3225abd9451813de2bc6506c7996fe4c6aR1-R31) (`src/react-platform/types/tour-provider.props.type.ts`, [[2]](diffhunk://#diff-5d762a2bf3c19b695ef2a604736c3b87162145129e7f21ed1d11c378c0b1f613R35-R38) (`src/react-native-platform/types/tour-provider.props.type.ts`, [[3]](diffhunk://#diff-ecb72044deba4e5291a55b48d8627bdc1c599920c8faf15ee9ecbabf49475a7cR33-R36)

### Tooltip component enhancements

* Refactored tooltip components (`src/react-platform/components/tour-tooltip.tsx`, `src/react-native-platform/components/tour-tooltip.tsx`) to use the new `i18n` props for all text labels, step counter templates, and accessibility strings, with sensible defaults provided. [[1]](diffhunk://#diff-d80766623d9f4a39b7cfe0ad1b5d2e182d89f9340aeee37ee090d57700b225cfR7-R36) [[2]](diffhunk://#diff-d80766623d9f4a39b7cfe0ad1b5d2e182d89f9340aeee37ee090d57700b225cfL71-R92) [[3]](diffhunk://#diff-d80766623d9f4a39b7cfe0ad1b5d2e182d89f9340aeee37ee090d57700b225cfL92-R113) [[4]](diffhunk://#diff-d80766623d9f4a39b7cfe0ad1b5d2e182d89f9340aeee37ee090d57700b225cfL103-R124) [[5]](diffhunk://#diff-8bad2d280da20be219586faf7091086168a182baf3c8e8e432d367dcf683d320R6-R14) [[6]](diffhunk://#diff-8bad2d280da20be219586faf7091086168a182baf3c8e8e432d367dcf683d320R28-R36) [[7]](diffhunk://#diff-8bad2d280da20be219586faf7091086168a182baf3c8e8e432d367dcf683d320L139-R156) [[8]](diffhunk://#diff-8bad2d280da20be219586faf7091086168a182baf3c8e8e432d367dcf683d320L161-R176) [[9]](diffhunk://#diff-8bad2d280da20be219586faf7091086168a182baf3c8e8e432d367dcf683d320L173-R188) [[10]](diffhunk://#diff-8bad2d280da20be219586faf7091086168a182baf3c8e8e432d367dcf683d320L182-R197)

### Provider integration

* Passed the `i18n` prop from `TourProvider` to tooltip components in both React and React Native implementations, ensuring internationalization settings flow through the tour context. (`src/react-platform/tour-provider.tsx`, [[1]](diffhunk://#diff-c06521e9380f83ab5a4c9da86388a62ed0d0410195d1f36a1dcf5435d2fdb9e2R31) [[2]](diffhunk://#diff-c06521e9380f83ab5a4c9da86388a62ed0d0410195d1f36a1dcf5435d2fdb9e2R282) (`src/react-native-platform/tour-provider.tsx`, [[3]](diffhunk://#diff-796b0ff099800f77267a7149c1e16eb0e153691eafad0d41e7962f1f5e48106fR31) [[4]](diffhunk://#diff-796b0ff099800f77267a7149c1e16eb0e153691eafad0d41e7962f1f5e48106fR277)

### Shared type exports

* Exported `TourI18n` from shared types and index files for use throughout the codebase. (`src/shared/types/index.ts`, [[1]](diffhunk://#diff-d57196e8ad49fc3165f73b5d95123249e723945981c2b4250490b169b852abbeR9) (`src/shared/index.ts`, [[2]](diffhunk://#diff-187de34251e329caefa8d99dd70ddf42bf57b832ed1c08a80c033ce09f657268R14)

### Version bump

* Updated package version to `0.3.0` to reflect the new features and breaking changes. (`package.json`, [package.jsonL3-R3](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3))