### PR TITLE
feat: add type export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@robertlinde/react-tour-kit",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@robertlinde/react-tour-kit",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@robertlinde/react-tour-kit",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Cross-platform guided tour library for React and React Native. Build interactive onboarding experiences with customizable tooltips, smart positioning, cross-page navigation, and async step actions. Fully themeable with TypeScript support.",
   "author": "Robert Linde",
   "license": "MIT",

--- a/src/react-native.ts
+++ b/src/react-native.ts
@@ -14,7 +14,7 @@ export {useTourTarget} from './react-native-platform';
 export {TourOverlay, TourTooltip} from './react-native-platform';
 
 // Types
-export type {TourStep, TourContextType, TourTooltipProps, TourOverlayProps, TourTheme} from './shared';
+export type {TourStep, TourContextType, TourTooltipProps, TourOverlayProps, TourTheme, TourI18n} from './shared';
 
 // Platform types
 export type {Rect, TourTarget} from './shared';

--- a/src/react.ts
+++ b/src/react.ts
@@ -12,7 +12,7 @@ export {TourContext, useTour} from './shared';
 export {TourOverlay, TourTooltip} from './react-platform';
 
 // Types
-export type {TourStep, TourContextType, TourTooltipProps, TourOverlayProps, TourTheme} from './shared';
+export type {TourStep, TourContextType, TourTooltipProps, TourOverlayProps, TourTheme, TourI18n} from './shared';
 
 // Platform types
 export type {Rect, TourTarget} from './shared';


### PR DESCRIPTION
This pull request introduces a minor version bump and expands the public API by re-exporting the `TourI18n` type from the shared types in both the React and React Native entry points. This makes it easier for consumers to access and use the internationalization type in their applications.

Versioning:

* Bumped the package version from `0.3.1` to `0.4.0` in `package.json` to reflect the new exported type and maintain semantic versioning.

API Improvements:

* Added `TourI18n` to the exported types in both `src/react.ts` and `src/react-native.ts`, making it available for consumers of both the React and React Native packages. [[1]](diffhunk://#diff-ca56e63fa839455c920562a44ebc44594f47957bbd3e9873c8a9e64104af2c41L15-R15) [[2]](diffhunk://#diff-2eb03c79436b0e9801fde914633f0e5259d161ac3436a5b6fd50c5691dd5c4ccL17-R17)