### PR TITLE
fix: visual fixes

### DIFF
--- a/src/react-native-platform/components/tour-overlay.tsx
+++ b/src/react-native-platform/components/tour-overlay.tsx
@@ -88,6 +88,34 @@ export function TourOverlay({highlightRect, onClose, theme}: TourOverlayProps): 
           ]}
         />
 
+        {/* Corner patches to round the cutout corners */}
+        {[
+          {
+            top: cutoutTop,
+            left: cutoutLeft,
+            childStyle: {bottom: 0, right: 0, borderBottomRightRadius: highlightBorderRadius},
+          },
+          {
+            top: cutoutTop,
+            left: cutoutLeft + cutoutWidth - highlightBorderRadius,
+            childStyle: {bottom: 0, left: 0, borderBottomLeftRadius: highlightBorderRadius},
+          },
+          {
+            top: cutoutTop + cutoutHeight - highlightBorderRadius,
+            left: cutoutLeft,
+            childStyle: {top: 0, right: 0, borderTopRightRadius: highlightBorderRadius},
+          },
+          {
+            top: cutoutTop + cutoutHeight - highlightBorderRadius,
+            left: cutoutLeft + cutoutWidth - highlightBorderRadius,
+            childStyle: {top: 0, left: 0, borderTopLeftRadius: highlightBorderRadius},
+          },
+        ].map((corner, i) => (
+          <View key={i} style={[styles.cornerPatch, {top: corner.top, left: corner.left}]}>
+            <View style={[styles.cornerFill, themedStyles.overlay, corner.childStyle]} />
+          </View>
+        ))}
+
         {/* Highlight border */}
         <View
           style={[
@@ -118,5 +146,16 @@ const styles = StyleSheet.create({
     position: 'absolute',
     borderWidth: 2,
     backgroundColor: 'transparent',
+  },
+  cornerPatch: {
+    position: 'absolute',
+    width: highlightBorderRadius,
+    height: highlightBorderRadius,
+    overflow: 'hidden',
+  },
+  cornerFill: {
+    position: 'absolute',
+    width: highlightBorderRadius * 2,
+    height: highlightBorderRadius * 2,
   },
 });

--- a/src/react-native-platform/components/tour-tooltip.tsx
+++ b/src/react-native-platform/components/tour-tooltip.tsx
@@ -1,6 +1,7 @@
 import {type ReactNode, forwardRef, type ForwardedRef, useMemo} from 'react';
 import type {View as ViewType, ViewStyle, TextStyle} from 'react-native';
 import {type TourTooltipProps} from '../../shared';
+import {getTruncatedDots, DOTS_CONTAINER_WIDTH, DOT_SIZE, DOT_GAP} from '../../shared/utils';
 
 const {View, Text, TouchableOpacity, StyleSheet} = require('react-native') as typeof import('react-native');
 
@@ -115,9 +116,16 @@ export const TourTooltip = forwardRef(function TourTooltip(
 
         {/* Step dots */}
         <View style={styles.dots}>
-          {Array.from({length: totalSteps}).map((_, index) => (
-            <View key={index} style={[styles.dot, index === currentStep && themedStyles.dotActive]} />
-          ))}
+          {getTruncatedDots(currentStep, totalSteps).map((item, i) =>
+            item.type === 'ellipsis' ? (
+              <View key={`ellipsis-${i}`} style={styles.ellipsis}>
+                <View style={styles.ellipsisDot} />
+                <View style={styles.ellipsisDot} />
+              </View>
+            ) : (
+              <View key={item.index} style={[styles.dot, item.index === currentStep && themedStyles.dotActive]} />
+            ),
+          )}
         </View>
 
         <TouchableOpacity style={[styles.navButton, themedStyles.nextButton]} onPress={onNext}>
@@ -214,12 +222,29 @@ const styles = StyleSheet.create({
   },
   dots: {
     flexDirection: 'row',
-    gap: 6,
+    gap: DOT_GAP,
+    width: DOTS_CONTAINER_WIDTH,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   dot: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
+    width: DOT_SIZE,
+    height: DOT_SIZE,
+    borderRadius: DOT_SIZE / 2,
+    backgroundColor: '#d1d5db',
+  },
+  ellipsis: {
+    width: DOT_SIZE,
+    height: DOT_SIZE,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 2,
+  },
+  ellipsisDot: {
+    width: 3,
+    height: 3,
+    borderRadius: 1.5,
     backgroundColor: '#d1d5db',
   },
 });

--- a/src/react-platform/components/tour-tooltip.tsx
+++ b/src/react-platform/components/tour-tooltip.tsx
@@ -2,6 +2,7 @@
 
 import {type JSX, type ForwardedRef, forwardRef} from 'react';
 import {type TourTooltipProps} from '../../shared';
+import {getTruncatedDots, DOTS_CONTAINER_WIDTH, DOT_SIZE, DOT_GAP} from '../../shared/utils';
 
 const defaultI18n = {
   nextLabel: 'Next',
@@ -119,20 +120,39 @@ function TourTooltipComponent(
     },
     dotsContainer: {
       display: 'flex',
-      gap: '6px',
+      gap: `${DOT_GAP}px`,
+      width: `${DOTS_CONTAINER_WIDTH}px`,
+      justifyContent: 'center',
+      alignItems: 'center',
     },
     dot: {
-      width: '8px',
-      height: '8px',
+      width: `${DOT_SIZE}px`,
+      height: `${DOT_SIZE}px`,
       borderRadius: '50%',
       border: 'none',
       cursor: 'pointer',
       padding: 0,
+      flexShrink: 0,
     },
     dotActive: {
       backgroundColor: theme.primaryColor,
     },
     dotInactive: {
+      backgroundColor: '#d1d5db',
+    },
+    ellipsis: {
+      width: `${DOT_SIZE}px`,
+      height: `${DOT_SIZE}px`,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: '2px',
+      flexShrink: 0,
+    },
+    ellipsisDot: {
+      width: '3px',
+      height: '3px',
+      borderRadius: '50%',
       backgroundColor: '#d1d5db',
     },
   };
@@ -177,20 +197,27 @@ function TourTooltipComponent(
           </button>
 
           <div style={styles.dotsContainer}>
-            {Array.from({length: totalSteps}).map((_, index) => (
-              <button
-                key={`step-${index}`}
-                type="button"
-                style={{
-                  ...styles.dot,
-                  ...(index === currentStep ? styles.dotActive : styles.dotInactive),
-                }}
-                aria-label={dotAriaLabelTemplate.replace('{step}', String(index + 1))}
-                onClick={() => {
-                  onGoToStep(index);
-                }}
-              />
-            ))}
+            {getTruncatedDots(currentStep, totalSteps).map((item, i) =>
+              item.type === 'ellipsis' ? (
+                <span key={`ellipsis-${i}`} style={styles.ellipsis}>
+                  <span style={styles.ellipsisDot} />
+                  <span style={styles.ellipsisDot} />
+                </span>
+              ) : (
+                <button
+                  key={`step-${item.index}`}
+                  type="button"
+                  style={{
+                    ...styles.dot,
+                    ...(item.index === currentStep ? styles.dotActive : styles.dotInactive),
+                  }}
+                  aria-label={dotAriaLabelTemplate.replace('{step}', String(item.index + 1))}
+                  onClick={() => {
+                    onGoToStep(item.index);
+                  }}
+                />
+              ),
+            )}
           </div>
 
           <button type="button" style={styles.nextButton} onClick={onNext}>

--- a/src/shared/utils/get-truncated-dots.util.ts
+++ b/src/shared/utils/get-truncated-dots.util.ts
@@ -1,0 +1,45 @@
+export const MAX_VISIBLE_DOTS = 7;
+export const DOT_SIZE = 8;
+export const DOT_GAP = 6;
+export const DOTS_CONTAINER_WIDTH = MAX_VISIBLE_DOTS * DOT_SIZE + (MAX_VISIBLE_DOTS - 1) * DOT_GAP;
+
+export type DotItem = {type: 'dot'; index: number} | {type: 'ellipsis'};
+
+export function getTruncatedDots(currentStep: number, totalSteps: number): DotItem[] {
+  if (totalSteps <= MAX_VISIBLE_DOTS) {
+    return Array.from({length: totalSteps}, (_, i) => ({type: 'dot' as const, index: i}));
+  }
+
+  const dots: DotItem[] = [];
+  const indices = new Set<number>([0, totalSteps - 1, currentStep]);
+
+  // Add neighbors of current step, expanding outward until we fill slots.
+  // Ellipsis markers also take a slot each, so we account for gaps.
+  for (let offset = 1; indices.size < MAX_VISIBLE_DOTS - countGaps(indices); offset++) {
+    if (currentStep - offset >= 0) indices.add(currentStep - offset);
+    if (currentStep + offset < totalSteps) indices.add(currentStep + offset);
+    if (offset > totalSteps) break;
+  }
+
+  const sorted = [...indices].toSorted((a, b) => a - b);
+
+  for (let i = 0; i < sorted.length; i++) {
+    if (i > 0 && sorted[i] - sorted[i - 1] > 1) {
+      dots.push({type: 'ellipsis'});
+    }
+
+    dots.push({type: 'dot', index: sorted[i]});
+  }
+
+  return dots;
+}
+
+function countGaps(indices: Set<number>): number {
+  const sorted = [...indices].toSorted((a, b) => a - b);
+  let gaps = 0;
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i] - sorted[i - 1] > 1) gaps++;
+  }
+
+  return gaps;
+}

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,1 +1,3 @@
 export {calculateTooltipPosition} from './calculate-tooltip-position.util';
+export {getTruncatedDots, MAX_VISIBLE_DOTS, DOT_SIZE, DOT_GAP, DOTS_CONTAINER_WIDTH} from './get-truncated-dots.util';
+export type {DotItem} from './get-truncated-dots.util';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "jsx": "react-jsx",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+    "lib": ["ES2023", "DOM", "DOM.Iterable"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
This pull request improves the usability and appearance of the tour tooltip step indicators and the overlay highlight for both React Native and React web platforms. The most significant changes are the introduction of a truncated step dot display with ellipsis for long tours, centralizing dot rendering logic, and visually enhancing the highlight cutout.

**Tour Step Dots Improvements:**

* Introduced a new utility function `getTruncatedDots` (with supporting constants and types) to limit the number of visible step dots to 7, displaying ellipsis when there are many steps. This provides a cleaner and more user-friendly navigation experience for long tours.
* Updated both `tour-tooltip.tsx` components (React Native and React web) to use `getTruncatedDots`, replacing the previous logic that rendered all dots. The new logic displays dots and ellipsis as needed, and applies consistent sizing and spacing using shared constants. [[1]](diffhunk://#diff-d80766623d9f4a39b7cfe0ad1b5d2e182d89f9340aeee37ee090d57700b225cfR4) [[2]](diffhunk://#diff-d80766623d9f4a39b7cfe0ad1b5d2e182d89f9340aeee37ee090d57700b225cfL118-R128) [[3]](diffhunk://#diff-d80766623d9f4a39b7cfe0ad1b5d2e182d89f9340aeee37ee090d57700b225cfL217-R247) [[4]](diffhunk://#diff-8bad2d280da20be219586faf7091086168a182baf3c8e8e432d367dcf683d320R5) [[5]](diffhunk://#diff-8bad2d280da20be219586faf7091086168a182baf3c8e8e432d367dcf683d320L122-R157) [[6]](diffhunk://#diff-8bad2d280da20be219586faf7091086168a182baf3c8e8e432d367dcf683d320L180-R220)
* Centralized and exported the dot sizing and spacing constants (`DOT_SIZE`, `DOT_GAP`, `DOTS_CONTAINER_WIDTH`) for use in both platforms, ensuring visual consistency. [[1]](diffhunk://#diff-788cfc2908ecd9972ca77b59280e9baaa89ff952ca2449dc506de87f4e002c02R1-R45) [[2]](diffhunk://#diff-3f86788d0afabf98884ee37c2ae0499a56271131bf188803e66a1591853e6e88R2-R3)

**Tour Overlay Visual Enhancement:**

* Added "corner patch" views in the React Native `TourOverlay` to round the corners of the highlight cutout, improving the overlay's appearance and matching the intended border radius. Supporting styles were added for these patches. [[1]](diffhunk://#diff-d62722dc29e1fcf09e1c1445e9791c9483e4c0da7948c0bcc8f7082364756d7bR91-R118) [[2]](diffhunk://#diff-d62722dc29e1fcf09e1c1445e9791c9483e4c0da7948c0bcc8f7082364756d7bR150-R160)