### PR TITLE
fix: tour placement

### DIFF
--- a/src/react-native-platform/components/tour-tooltip.tsx
+++ b/src/react-native-platform/components/tour-tooltip.tsx
@@ -1,5 +1,5 @@
-import {type ReactNode, forwardRef, type ForwardedRef, useMemo} from 'react';
-import type {View as ViewType, ViewStyle, TextStyle} from 'react-native';
+import {type ReactNode, forwardRef, type ForwardedRef, useCallback, useMemo} from 'react';
+import type {View as ViewType, ViewStyle, TextStyle, LayoutChangeEvent} from 'react-native';
 import {type TourTooltipProps} from '../../shared';
 import {getTruncatedDots, DOTS_CONTAINER_WIDTH, DOT_SIZE, DOT_GAP} from '../../shared/utils';
 
@@ -28,6 +28,7 @@ export const TourTooltip = forwardRef(function TourTooltip(
     onClose,
     onNext,
     onPrev,
+    onMeasured,
     theme,
     i18n,
   }: TourTooltipProps,
@@ -37,6 +38,18 @@ export const TourTooltip = forwardRef(function TourTooltip(
 
   const isFirstStep = currentStep === 0;
   const isLastStep = currentStep === totalSteps - 1;
+
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent): void => {
+      if (!onMeasured) {
+        return;
+      }
+
+      const {width, height} = event.nativeEvent.layout;
+      onMeasured({width, height});
+    },
+    [onMeasured],
+  );
 
   const themedStyles = useMemo(
     (): {
@@ -85,6 +98,7 @@ export const TourTooltip = forwardRef(function TourTooltip(
           opacity: isPositioned ? 1 : 0,
         },
       ]}
+      onLayout={handleLayout}
     >
       {/* Header */}
       <View style={styles.header}>

--- a/src/react-native-platform/platform-adapter.ts
+++ b/src/react-native-platform/platform-adapter.ts
@@ -73,9 +73,11 @@ export const nativePlatformAdapter: PlatformAdapter = {
   },
 
   measureTooltip(): {width: number; height: number} {
-    // In React Native, we typically use onLayout to get dimensions
-    // For initial render, return defaults - actual dimensions come from onLayout
-    // This is a limitation compared to web, but works with the retry logic
+    // React Native cannot synchronously report a View's rendered size. The
+    // provider instead passes an onMeasured callback to the tooltip component
+    // which reports dimensions via onLayout after the first render, and the
+    // position is then recalculated with the accurate size. This adapter
+    // method is kept for interface parity with the web adapter.
     return {width: 0, height: 0};
   },
 

--- a/src/react-native-platform/tour-provider.tsx
+++ b/src/react-native-platform/tour-provider.tsx
@@ -43,6 +43,7 @@ export function TourProvider({
   const [tooltipPosition, setTooltipPosition] = useState({top: 0, left: 0});
   const [isPositioned, setIsPositioned] = useState(false);
   const [highlightRect, setHighlightRect] = useState<Rect | undefined>(undefined);
+  const [tooltipSize, setTooltipSize] = useState({width: 0, height: 0});
   const tooltipRef = useRef<ViewType>(null);
   const [positionKey, setPositionKey] = useState(0);
   const tourOnEndRef = useRef<TourEndCallback | undefined>(undefined);
@@ -85,10 +86,21 @@ export function TourProvider({
       setCurrentTourId(undefined);
       setHighlightRect(undefined);
       setTooltipPosition({top: 0, left: 0});
+      setTooltipSize({width: 0, height: 0});
       setIsPositioned(false);
     },
     [currentTourId, currentStep, steps, onTourEnd],
   );
+
+  const handleTooltipMeasured = useCallback((size: {width: number; height: number}): void => {
+    setTooltipSize((previous) => {
+      if (previous.width === size.width && previous.height === size.height) {
+        return previous;
+      }
+
+      return size;
+    });
+  }, []);
 
   // Context-exposed endTour stays compatible with existing consumers.
   // Defaults to 'closed' since a direct `useTour().endTour()` call is
@@ -145,13 +157,12 @@ export function TourProvider({
       setHighlightRect(rect);
 
       const placement = currentTourStep.placement ?? defaultPlacement;
-      const tooltipDimensions = platform.measureTooltip(tooltipRef);
       const viewportDimensions = platform.getViewportDimensions();
-      const position = calculateTooltipPosition(rect, placement, tooltipDimensions, viewportDimensions);
+      const position = calculateTooltipPosition(rect, placement, tooltipSize, viewportDimensions);
       setTooltipPosition(position);
       setIsPositioned(true);
     })();
-  }, [isActive, currentStep, steps, finishTour, platform]);
+  }, [isActive, currentStep, steps, finishTour, platform, tooltipSize]);
 
   // Handle step transitions and onBeforeStep callbacks
   useEffect(() => {
@@ -185,6 +196,9 @@ export function TourProvider({
 
       setHighlightRect(rect);
       setIsPositioned(false);
+      // Reset tooltip size so a stale measurement from the previous step can't
+      // place the next tooltip incorrectly on its first frame.
+      setTooltipSize({width: 0, height: 0});
 
       // Trigger positioning - scrolling happens after tooltip is measured
       setTimeout(() => {
@@ -228,15 +242,14 @@ export function TourProvider({
           setHighlightRect(rect);
 
           const placement = currentTourStep.placement ?? defaultPlacement;
-          const tooltipDimensions = platform.measureTooltip(tooltipRef);
           const viewportDimensions = platform.getViewportDimensions();
-          const position = calculateTooltipPosition(rect, placement, tooltipDimensions, viewportDimensions);
+          const position = calculateTooltipPosition(rect, placement, tooltipSize, viewportDimensions);
 
           setTooltipPosition(position);
           setIsPositioned(true);
 
           // Scroll after positioning so we have actual tooltip dimensions
-          await platform.scrollToElement(currentTourStep.target, placement, tooltipDimensions.height);
+          await platform.scrollToElement(currentTourStep.target, placement, tooltipSize.height);
         })();
       });
     };
@@ -249,7 +262,7 @@ export function TourProvider({
         platform.cancelFrame(animationFrameId);
       }
     };
-  }, [isActive, currentStep, steps, highlightRect, positionKey, platform]);
+  }, [isActive, currentStep, steps, highlightRect, positionKey, platform, tooltipSize]);
 
   // Keyboard/back button navigation
   useEffect(() => {
@@ -323,6 +336,7 @@ export function TourProvider({
                 totalSteps={steps.length}
                 onClose={endTour}
                 onGoToStep={goToStep}
+                onMeasured={handleTooltipMeasured}
                 onNext={nextStep}
                 onPrev={previousStep}
               />

--- a/src/shared/types/tour-tooltip-props.type.ts
+++ b/src/shared/types/tour-tooltip-props.type.ts
@@ -29,4 +29,10 @@ export type TourTooltipProps = {
   readonly theme: Required<TourTheme>;
   /** Internationalization options for customizing text strings. */
   readonly i18n?: TourI18n;
+  /**
+   * Called by the tooltip component after it has been laid out, with its actual rendered size.
+   * The provider uses this on platforms where tooltip dimensions cannot be measured synchronously
+   * (e.g. React Native) to re-run position calculation with accurate dimensions.
+   */
+  readonly onMeasured?: (size: {width: number; height: number}) => void;
 };


### PR DESCRIPTION
This pull request improves how the tooltip's size is measured and used for positioning in the React Native tour component. Instead of relying on default or stale dimensions, the tooltip now reports its actual rendered size via an `onMeasured` callback, allowing for accurate and responsive positioning during tour steps. The update ensures that tooltips are positioned correctly, especially when their size changes between steps.

Key changes include:

**Tooltip Measurement and Reporting:**
- Added an `onMeasured` callback to `TourTooltipProps` and the `TourTooltip` component, which is called after the tooltip is laid out with its actual size. This enables the provider to receive precise tooltip dimensions on React Native, where synchronous measurement isn't possible. [[1]](diffhunk://#diff-eb23931e10142f08a5291ba4a3cdec3225abd9451813de2bc6506c7996fe4c6aR32-R37) [[2]](diffhunk://#diff-d80766623d9f4a39b7cfe0ad1b5d2e182d89f9340aeee37ee090d57700b225cfR31) [[3]](diffhunk://#diff-d80766623d9f4a39b7cfe0ad1b5d2e182d89f9340aeee37ee090d57700b225cfR42-R53) [[4]](diffhunk://#diff-d80766623d9f4a39b7cfe0ad1b5d2e182d89f9340aeee37ee090d57700b225cfR101)

**Provider State and Positioning Logic:**
- The provider now tracks the tooltip's size in state and recalculates its position using the measured dimensions. This ensures tooltips are always positioned based on their real size, improving accuracy across step transitions and rerenders. [[1]](diffhunk://#diff-796b0ff099800f77267a7149c1e16eb0e153691eafad0d41e7962f1f5e48106fR46) [[2]](diffhunk://#diff-796b0ff099800f77267a7149c1e16eb0e153691eafad0d41e7962f1f5e48106fR89-R104) [[3]](diffhunk://#diff-796b0ff099800f77267a7149c1e16eb0e153691eafad0d41e7962f1f5e48106fL148-R165) [[4]](diffhunk://#diff-796b0ff099800f77267a7149c1e16eb0e153691eafad0d41e7962f1f5e48106fR199-R201) [[5]](diffhunk://#diff-796b0ff099800f77267a7149c1e16eb0e153691eafad0d41e7962f1f5e48106fL231-R252) [[6]](diffhunk://#diff-796b0ff099800f77267a7149c1e16eb0e153691eafad0d41e7962f1f5e48106fL252-R265) [[7]](diffhunk://#diff-796b0ff099800f77267a7149c1e16eb0e153691eafad0d41e7962f1f5e48106fR339)

**Platform Adapter Documentation:**
- Updated the React Native platform adapter's `measureTooltip` method documentation to clarify that actual measurement is now handled asynchronously via the new callback, and that the method is retained only for interface compatibility.

**Type and Import Updates:**
- Updated type definitions and imports to support the new measurement callback and event types.

These changes make the tour tooltip more robust and visually consistent, especially when dealing with dynamic content or step transitions.