### PR TITLE
fix: jumping tour

### DIFF
--- a/src/react-native-platform/tour-provider.tsx
+++ b/src/react-native-platform/tour-provider.tsx
@@ -246,7 +246,12 @@ export function TourProvider({
           const position = calculateTooltipPosition(rect, placement, tooltipSize, viewportDimensions);
 
           setTooltipPosition(position);
-          setIsPositioned(true);
+          // Only reveal the tooltip once we have its real measured size. Showing it
+          // earlier flashes it at a position computed from the default-height fallback,
+          // then visibly jumps when onLayout reports the real dimensions.
+          if (tooltipSize.height > 0 && tooltipSize.width > 0) {
+            setIsPositioned(true);
+          }
 
           // Scroll after positioning so we have actual tooltip dimensions
           await platform.scrollToElement(currentTourStep.target, placement, tooltipSize.height);


### PR DESCRIPTION
This pull request improves the user experience in the `TourProvider` component by ensuring that tooltips are only revealed after their actual size has been measured, preventing visual glitches caused by premature rendering.

Tooltip display and positioning improvements:

* Updated `TourProvider` to only set `isPositioned` to `true` (which reveals the tooltip) once the tooltip's real measured size is known, avoiding a visible jump that occurred when the tooltip was first displayed using a default size.