### PR TITLE
fix: hide and show on transition

### DIFF
--- a/src/react-native-platform/tour-provider.tsx
+++ b/src/react-native-platform/tour-provider.tsx
@@ -195,10 +195,14 @@ export function TourProvider({
       }
 
       setHighlightRect(rect);
-      setIsPositioned(false);
-      // Reset tooltip size so a stale measurement from the previous step can't
-      // place the next tooltip incorrectly on its first frame.
-      setTooltipSize({width: 0, height: 0});
+      // Intentionally do not reset isPositioned or tooltipSize here. Keeping
+      // the previous step's measurement lets the next step's tooltip move
+      // directly to its new position instead of flashing invisible while we
+      // wait for onLayout to refire. onLayout will update tooltipSize on the
+      // next frame if the new content has a different height; the position
+      // effect then re-runs with the latest size. Only the very first step of
+      // a tour starts with isPositioned=false (from useState), preserving the
+      // opacity-0 first-render behavior that prevents the initial jump.
 
       // Trigger positioning - scrolling happens after tooltip is measured
       setTimeout(() => {


### PR DESCRIPTION
This pull request makes a targeted adjustment to the tooltip positioning logic in the `TourProvider` component. The main change is to avoid resetting the tooltip's position and size state on each step, which prevents the tooltip from flashing invisible between tour steps and results in a smoother user experience.

**Tooltip behavior improvements:**

* [`src/react-native-platform/tour-provider.tsx`](diffhunk://#diff-796b0ff099800f77267a7149c1e16eb0e153691eafad0d41e7962f1f5e48106fL198-R205): Changed the logic so that `isPositioned` and `tooltipSize` are no longer reset when moving to a new tour step, allowing the tooltip to smoothly transition to its new position without becoming invisible. The initial step still starts with `isPositioned=false` to preserve the intended first-render behavior.