### PR TITLE
feat: expose target ref in onBeforeStep

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,10 +274,12 @@ function Home() {
       title: 'Settings Link',
       content: "Now let's visit the settings page.",
       placement: 'bottom',
-      // Navigate before the NEXT step shows
-      onBeforeStep: async () => {
+      // Navigate before the NEXT step shows, then poll until its target mounts
+      onBeforeStep: async (target) => {
         navigate('/settings');
-        await new Promise((r) => setTimeout(r, 100)); // Wait for navigation
+        while (!document.querySelector(target as string)) {
+          await new Promise((r) => setTimeout(r, 50));
+        }
       },
     },
     {
@@ -291,9 +293,11 @@ function Home() {
       title: 'Back Home',
       content: 'And we can navigate back.',
       placement: 'bottom',
-      onBeforeStep: async () => {
+      onBeforeStep: async (target) => {
         navigate('/');
-        await new Promise((r) => setTimeout(r, 100));
+        while (!document.querySelector(target as string)) {
+          await new Promise((r) => setTimeout(r, 50));
+        }
       },
     },
   ];
@@ -343,7 +347,7 @@ function HomeScreen() {
       title: 'Settings Screen',
       content: 'This element is on the Settings screen!',
       placement: 'bottom',
-      onBeforeStep: async () => {
+      onBeforeStep: async (target) => {
         navigation.navigate('Settings');
         await new Promise((r) => setTimeout(r, 300)); // Wait for animation
       },
@@ -353,7 +357,7 @@ function HomeScreen() {
       title: 'Back Home',
       content: 'And we can navigate back.',
       placement: 'bottom',
-      onBeforeStep: async () => {
+      onBeforeStep: async (target) => {
         navigation.navigate('Home');
         await new Promise((r) => setTimeout(r, 300));
       },
@@ -379,7 +383,7 @@ function SettingsScreen() {
 
 1. **TourProvider placement**: Must wrap your router/navigator so tour state persists across navigation
 2. **Target availability**: Targets must be mounted when their step is active. Use `onBeforeStep` to navigate first
-3. **Wait for navigation**: Add a small delay after navigation to ensure the new page/screen is rendered
+3. **Wait for navigation**: On web, poll on the `target` argument in `onBeforeStep` (e.g. `while (!document.querySelector(target))`) instead of a fixed delay. On React Native, a short delay is usually fine because navigation animations have a known duration.
 4. **Persistent elements**: Elements like navigation bars that exist on all pages don't need `onBeforeStep`
 
 ---
@@ -451,7 +455,7 @@ type TourStep = {
   title: string; // Step title
   content: string; // Step description/content
   placement?: 'top' | 'bottom' | 'left' | 'right'; // Tooltip position (default: 'bottom')
-  onBeforeStep?: () => void | Promise<void>; // Async action before showing step
+  onBeforeStep?: (target: TourTarget) => void | Promise<void>; // Async action before showing step; receives the step's target so you can poll until it mounts
 };
 
 // Target types differ by platform:
@@ -759,11 +763,13 @@ const steps: TourStep[] = [
     target: '[data-tour="notifications-panel"]',
     title: 'Notifications',
     content: 'Configure your notification preferences here.',
-    onBeforeStep: async () => {
+    onBeforeStep: async (target) => {
       // Open the settings tab before showing this step
       document.querySelector('[data-tour="settings-tab"]')?.click();
-      // Wait for the panel to appear
-      await new Promise((resolve) => setTimeout(resolve, 300));
+      // Poll until the panel actually mounts instead of guessing a delay
+      while (!document.querySelector(target as string)) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
     },
   },
 ];

--- a/src/react-native-platform/tour-provider.tsx
+++ b/src/react-native-platform/tour-provider.tsx
@@ -177,7 +177,7 @@ export function TourProvider({
 
     const runStep = async (): Promise<void> => {
       if (currentTourStep.onBeforeStep) {
-        await currentTourStep.onBeforeStep();
+        await currentTourStep.onBeforeStep(currentTourStep.target);
         await new Promise<void>((resolve) => {
           setTimeout(resolve, domUpdateDelayMs);
         });

--- a/src/react-platform/tour-provider.tsx
+++ b/src/react-platform/tour-provider.tsx
@@ -171,7 +171,7 @@ export function TourProvider({
 
     const runStep = async (): Promise<void> => {
       if (currentTourStep.onBeforeStep) {
-        await currentTourStep.onBeforeStep();
+        await currentTourStep.onBeforeStep(currentTourStep.target);
         await new Promise<void>((resolve) => {
           setTimeout(resolve, domUpdateDelayMs);
         });

--- a/src/shared/types/tour-step.type.ts
+++ b/src/shared/types/tour-step.type.ts
@@ -10,6 +10,9 @@ export type TourStep = {
   title: string;
   content: string;
   placement?: Placement;
-  /** Called before this step is shown. Use to switch tabs, open dialogs, etc. */
-  onBeforeStep?: () => void | Promise<void>;
+  /**
+   * Called before this step is shown. Use to switch tabs, open dialogs, navigate, etc.
+   * Receives the step's `target` so the callback can poll until the element mounts.
+   */
+  onBeforeStep?: (target: TourTarget) => void | Promise<void>;
 };


### PR DESCRIPTION
This pull request improves the reliability of the guided tour steps by updating how navigation and target element availability are handled. The main change is that the `onBeforeStep` callback now receives the step's `target` as an argument, allowing it to poll for the target element to be present before proceeding. This reduces issues caused by fixed delays and makes the tour more robust across navigation events. Documentation and type definitions have also been updated to reflect this change.

**Tour step API and type changes:**

* Updated the `TourStep` type to have `onBeforeStep` accept the step's `target` as an argument, allowing callbacks to poll for the target element before showing the step (`src/shared/types/tour-step.type.ts`, `README.md`). ([src/shared/types/tour-step.type.tsL13-R17](diffhunk://#diff-11d351584917e2fd688d90ae5a6ae27771a025c3c0884900ca7b9ba215e2d066L13-R17), F451R455)

**Implementation updates:**

* Modified both web and React Native tour providers to pass the `target` to `onBeforeStep` when running a step (`src/react-platform/tour-provider.tsx`, `src/react-native-platform/tour-provider.tsx`). [[1]](diffhunk://#diff-c06521e9380f83ab5a4c9da86388a62ed0d0410195d1f36a1dcf5435d2fdb9e2L174-R174) [[2]](diffhunk://#diff-796b0ff099800f77267a7149c1e16eb0e153691eafad0d41e7962f1f5e48106fL180-R180)

**Tour step logic improvements:**

* Updated all `onBeforeStep` usages in tour steps to use the `target` argument and poll for the target element to mount (using `document.querySelector(target)` in web), instead of relying on a fixed delay (`README.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L277-R282) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L294-R300) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L762-R772)

**Documentation updates:**

* Clarified in the documentation that polling for the target element is preferred on web, while a fixed delay is usually sufficient on React Native due to predictable navigation timing (`README.md`).