### PR TITLE
fix: export getTruncatedDots and dot layout constants

### DIFF
--- a/src/react-native.ts
+++ b/src/react-native.ts
@@ -34,6 +34,10 @@ export type {Rect, TourTarget} from './shared';
 
 export {calculateTooltipPosition} from './shared';
 
+export {getTruncatedDots, MAX_VISIBLE_DOTS, DOT_SIZE, DOT_GAP, DOTS_CONTAINER_WIDTH} from './shared';
+
+export type {DotItem} from './shared';
+
 // Platform adapter (for advanced customization)
 
 export {nativePlatformAdapter, targetRegistry} from './react-native-platform';

--- a/src/react.ts
+++ b/src/react.ts
@@ -32,6 +32,10 @@ export type {Rect, TourTarget} from './shared';
 
 export {calculateTooltipPosition} from './shared';
 
+export {getTruncatedDots, MAX_VISIBLE_DOTS, DOT_SIZE, DOT_GAP, DOTS_CONTAINER_WIDTH} from './shared';
+
+export type {DotItem} from './shared';
+
 export {findVisibleElement} from './react-platform';
 
 // Platform adapter (for advanced customization)

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -31,3 +31,7 @@ export {useTour} from './hooks';
 // Utils
 
 export {calculateTooltipPosition} from './utils';
+
+export {getTruncatedDots, MAX_VISIBLE_DOTS, DOT_SIZE, DOT_GAP, DOTS_CONTAINER_WIDTH} from './utils';
+
+export type {DotItem} from './utils';


### PR DESCRIPTION
This pull request adds new exports related to dot navigation and their types to the React, React Native, and shared entry points. These changes make utility functions and constants for managing dot navigation available for consumers of the library, improving reusability and consistency across platforms.

**Dot navigation utilities and types:**

* Added exports for `getTruncatedDots`, `MAX_VISIBLE_DOTS`, `DOT_SIZE`, `DOT_GAP`, and `DOTS_CONTAINER_WIDTH` from `./shared` (React and React Native) and `./utils` (shared), making these dot navigation utilities and constants available for use. [[1]](diffhunk://#diff-ca56e63fa839455c920562a44ebc44594f47957bbd3e9873c8a9e64104af2c41R35-R38) [[2]](diffhunk://#diff-2eb03c79436b0e9801fde914633f0e5259d161ac3436a5b6fd50c5691dd5c4ccR37-R40) [[3]](diffhunk://#diff-187de34251e329caefa8d99dd70ddf42bf57b832ed1c08a80c033ce09f657268R34-R37)
* Exported the `DotItem` type from the same modules, allowing type-safe usage of dot navigation items. [[1]](diffhunk://#diff-ca56e63fa839455c920562a44ebc44594f47957bbd3e9873c8a9e64104af2c41R35-R38) [[2]](diffhunk://#diff-2eb03c79436b0e9801fde914633f0e5259d161ac3436a5b6fd50c5691dd5c4ccR37-R40) [[3]](diffhunk://#diff-187de34251e329caefa8d99dd70ddf42bf57b832ed1c08a80c033ce09f657268R34-R37)